### PR TITLE
Relax requests version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,14 +8,14 @@ except ImportError:
 
 setup(
     name='silverpop',
-    version='1.0.3',
+    version='1.0.4',
     description='Silverpop API wrapper.',
     author='Thomas Welfley',
     author_email='thomas@yola.com',
     url='https://github.com/yola/silverpop',
     packages=['silverpop', ],
     install_requires=[
-        'requests==2.11.1',
+        'requests>=2.11.1',
         # 'elementtree==1.2.7-20070827-preview',
         # 'testify==0.1.12',
     ],


### PR DESCRIPTION
When silverpop was being ported to python3 the requests version it depends on was pinned https://github.com/SportPursuit/silverpop/commit/26f328f6f521ca5f283548fc617bd8cc57c0f043 

This has gotten a bit out of date and breaks in python 3.10 environments (which we noticed when installing it with the sp package).

I can't really see a reason why requests would break their interface in future versions but I could also cap the pin to be <=2.31.0 as the current version seems to work fine?